### PR TITLE
Add STRING ports

### DIFF
--- a/Examples/CppDataTypeTest/README.md
+++ b/Examples/CppDataTypeTest/README.md
@@ -43,12 +43,14 @@ All supported elementary data types are documented in the [PLCnext Info Center](
 
 ## PLCnext Engineer project
 
-1. In PLCnext Engineer create a project and include the "CppDataTypeTest.pcwlx" in the project.
+1. In PLCnext Engineer create a new project and add the user library "CppDataTypeTest.pcwlx" to the project.
 1. Instantiate the program "CppDataTypeTestProgram" under a previously defined task.
 1. In the "COMPONENT" area under "Programming" -> "Datatypes" create an new datatype worksheet and include the following user-defined datatypes:
 
 	```text
 			TYPE
+				STRING420:STRING[420];
+
 				s_alltypes : STRUCT
 				
 					outInt8: SINT;
@@ -71,34 +73,38 @@ All supported elementary data types are documented in the [PLCnext Info Center](
 					
 					outFloat32:Real;
 					outFloat64:LREAL;
+
+					outString:STRING;
 				END_STRUCT
 
 				
-			bool_array: ARRAY[0..9] OF BOOL;  
+			bool_array: ARRAY[0..9] OF BOOL;
 			//8Bit
-			sint_array: ARRAY[0..9] OF SINT;  
-			usint_array: ARRAY[0..9] OF USINT;  
+			sint_array: ARRAY[0..9] OF SINT;
+			usint_array: ARRAY[0..9] OF USINT;
 			//16Bit
-			int_array: ARRAY[0..9] OF INT;  
-			uint_array: ARRAY[0..9] OF UINT;  
+			int_array: ARRAY[0..9] OF INT;
+			uint_array: ARRAY[0..9] OF UINT;
 			//32Bit
-			dint_array: ARRAY[0..9] OF DINT;  
-			udint_array: ARRAY[0..9] OF UDINT;  
+			dint_array: ARRAY[0..9] OF DINT;
+			udint_array: ARRAY[0..9] OF UDINT;
 			//64Bit
-			lint_array: ARRAY[0..9] OF LINT;  
-			ulint_array: ARRAY[0..9] OF ULINT;  
+			lint_array: ARRAY[0..9] OF LINT;
+			ulint_array: ARRAY[0..9] OF ULINT;
 			//8Bit
-			byte_array: ARRAY[0..9] OF BYTE;  
+			byte_array: ARRAY[0..9] OF BYTE;
 			//16Bit
-			word_array: ARRAY[0..9] OF WORD;  
+			word_array: ARRAY[0..9] OF WORD;
 			//32Bit
-			doubleword_array: ARRAY[0..9] OF DWORD;  
+			doubleword_array: ARRAY[0..9] OF DWORD;
 			//64Bit
-			Lword_array: ARRAY[0..9] OF LWORD;  
+			Lword_array: ARRAY[0..9] OF LWORD;
 			//xx digit precision
-			real_array: ARRAY[0..9] OF REAL;  
+			real_array: ARRAY[0..9] OF REAL;
 			//xx digit precision
-			Lreal_array: ARRAY[0..9] OF LREAL;  
+			Lreal_array: ARRAY[0..9] OF LREAL;
+			//String
+			String_array: ARRAY[0..9] OF STRING;
 			END_TYPE
 	```
 
@@ -116,261 +122,283 @@ All supported elementary data types are documented in the [PLCnext Info Center](
 ### CppDataTypeTestProgram.hpp
 
 ```cpp
-		/******************************************************************************
-		 * 
-		 * Copyright (c) Phoenix Contact GmbH & Co. KG. All rights reserved.  
-		 * Licensed under the MIT. See LICENSE file in the project root for full license information.  
-		 *
-		 *  CppDataTypeTestProgram.hpp
-		 *
-		 *  Created on: 21.02.2019
-		 *  	Author: Eduard Münz, Oliver Warneke
-		 *
-		 ******************************************************************************/
+/******************************************************************************
+ * 
+ * Copyright (c) Phoenix Contact GmbH & Co. KG. All rights reserved.  
+ * Licensed under the MIT. See LICENSE file in the project root for full license information.  
+ *
+ *  CppDataTypeTestProgram.hpp
+ *
+ *  Created on: 21.02.2019
+ *  	Author: Eduard Münz, Oliver Warneke, Martin Boers
+ *
+ ******************************************************************************/
 
-		/******************************************************************************/
-		/*  INCLUDES                                                                  */
-		/******************************************************************************/
-		#pragma once
-		#include "Arp/System/Core/Arp.h"
-		#include "Arp/Plc/Commons/Esm/ProgramBase.hpp"
-		#include "Arp/System/Commons/Logging.h"
-		#include "CppDataTypeTestComponent.hpp"
+/******************************************************************************/
+/*  INCLUDES                                                                  */
+/******************************************************************************/
+#pragma once
+#include "Arp/System/Core/Arp.h"
+#include "Arp/Plc/Commons/Esm/ProgramBase.hpp"
+#include "Arp/System/Commons/Logging.h"
+#include "CppDataTypeTestComponent.hpp"
 
-		namespace CppDataTypeTest
-		{
+namespace CppDataTypeTest
+{
 
-		using namespace Arp;
-		using namespace Arp::System::Commons::Diagnostics::Logging;
-		using namespace Arp::Plc::Commons::Esm;
+using namespace Arp;
+using namespace Arp::System::Commons::Diagnostics::Logging;
+using namespace Arp::Plc::Commons::Esm;
 
-		//#program
-		//#component(CppDataTypeTest::CppDataTypeTestComponent)
-		class CppDataTypeTestProgram : public ProgramBase, private Loggable<CppDataTypeTestProgram>
-		{
-		public: // typedefs
-
-
-			struct s_alltypes{
-
-				int8	outInt8		=	0; 	//SINT
-				uint8	outUint8	=	0;	//USINT
-
-				int16	outInt16	=	0;	//INT
-				uint16	outUint16	=	0;	//UINT
-
-				int32	outInt32	=	0;	//DINT
-				uint32	outUint32	=	0;	//UDINT
-
-				int64 	outInt64	=	0;	//LINT
-				uint64	outUint64	=	0;	//ULINT
-
-				boolean outBoolean	=	false;	// BOOL
-				uint8	outByte		=	0;	//Byte
-				uint16	outWord		=	0;	//Word
-				uint32	outDword	=	0;	//DWORD
-				uint64	outLword	=	0;	//LWORD
-
-				float32	outFloat32	=	0.0;	//Real
-				float64	outFloat64	=	0.0;	//LREAL
-
-			};
-
-		public: // construction/destruction
-			CppDataTypeTestProgram(CppDataTypeTest::CppDataTypeTestComponent& cppDataTypeTestComponentArg, const String& name);
-			CppDataTypeTestProgram(const CppDataTypeTestProgram& arg) = delete;
-			virtual ~CppDataTypeTestProgram() = default;
-
-		public: // operators
-			CppDataTypeTestProgram&  operator=(const CppDataTypeTestProgram& arg) = delete;
-
-		public: // properties
-
-		public: // operations
-			void    Execute() override;
-
-		public: /* Ports
-				   =====
-				   Ports are defined in the following way:
-				   //#port
-				   //#attributes(Input|Retain)
-				   //#name(NameOfPort)
-				   boolean portField;
-
-				   The attributes comment defines the port attributes and is optional.
-				   The name comment defines the name of the port and is optional. Default is the name of the field.
-				*/
-
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outBoolean)
-			boolean	outBoolean	=	false;	//BOOL
-
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outInt8)
-			int8	outInt8		=	0; 		//SINT
-
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outUint8)
-			uint8	outUint8	=	0;		//USINT
-
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outInt16)
-			int16	outInt16	=	0;		//INT
-
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outUint16)
-			uint16	outUint16	=	0;		//UINT
-
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outInt32)
-			int32	outInt32	=	0;		//DINT
-
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outUint32)
-			uint32	outUint32	=	0;		//UDINT
-
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outInt64)
-			int64 	outInt64	=	0;		//LINT
-
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outUint64)
-			uint64	outUint64	=	0;		//ULINT
-
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outByte)
-			uint8	outByte		=	0;		//Byte
-
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outWord)
-			uint16	outWord		=	0;		//Word
-
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outDword)
-			uint32	outDword	=	0;		//DWORD
-
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outLword)
-			uint64	outLword	=	0;		//LWORD
-
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outFloat32)
-			float32	outFloat32	=	0.0;	//Real
-
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outFloat64)
-			float64	outFloat64	=	0.0;	//LREAL
+//#program
+//#component(CppDataTypeTest::CppDataTypeTestComponent)
+class CppDataTypeTestProgram : public ProgramBase, private Loggable<CppDataTypeTestProgram>
+{
+public: // typedefs
 
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outStruct)
-			s_alltypes outStruct;
+	struct s_alltypes{
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outarrayBoolean)
-			boolean	outarrayBoolean	[10] = {false};	//BOOL
+		int8	outInt8		=	0; 	//SINT
+		uint8	outUint8	=	0;	//USINT
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outarrayInt8)
-			int8	outarrayInt8[10] = {0};		//SINT
+		int16	outInt16	=	0;	//INT
+		uint16	outUint16	=	0;	//UINT
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outarrayUint8)
-			uint8	outarrayUint8[10] = {0};	//USINT
+		int32	outInt32	=	0;	//DINT
+		uint32	outUint32	=	0;	//UDINT
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outarrayInt16)
-			int16	outarrayInt16[10] = {0};	//INT
+		int64 	outInt64	=	0;	//LINT
+		uint64	outUint64	=	0;	//ULINT
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outarrayUint16)
-			uint16	outarrayUint16[10] = {0};	//UINT
+		boolean outBoolean	=	false;	// BOOL
+		uint8	outByte		=	0;	//Byte
+		uint16	outWord		=	0;	//Word
+		uint32	outDword	=	0;	//DWORD
+		uint64	outLword	=	0;	//LWORD
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outarrayInt32)
-			int32	outarrayInt32[10] = {0};	//DINT
+		float32	outFloat32	=	0.0;	//Real
+		float64	outFloat64	=	0.0;	//LREAL
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outarrayUint32)
-			uint32	outarrayUint32[10] = {0};	//UDINT
+		StaticString<80> outString = "";  // String
+		// Structs containing custom-length strings  are currently not supported by PLCnext Engineer (version 2020.6).
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outarrayInt64)
-			int64 	outarrayInt64[10] = {0};	//LINT
+	};
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outarrayUint64)
-			uint64	outarrayUint64[10] = {0};	//ULINT
+public: // construction/destruction
+    CppDataTypeTestProgram(CppDataTypeTest::CppDataTypeTestComponent& cppDataTypeTestComponentArg, const String& name);
+    CppDataTypeTestProgram(const CppDataTypeTestProgram& arg) = delete;
+    virtual ~CppDataTypeTestProgram() = default;
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outarrayByte)
-			uint8	outarrayByte[10] = {0};		//Byte
+public: // operators
+    CppDataTypeTestProgram&  operator=(const CppDataTypeTestProgram& arg) = delete;
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outarrayWord)
-			uint16	outarrayWord[10] = {0};		//Word
+public: // properties
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outarrayDword)
-			uint32	outarrayDword[10] = {0};	//DWORD
+public: // operations
+    void    Execute() override;
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outarrayLword)
-			uint64	outarrayLword[10] = {0};	//LWORD
+public: /* Ports
+           =====
+           Ports are defined in the following way:
+           //#port
+           //#attributes(Input|Retain)
+           //#name(NameOfPort)
+           boolean portField;
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outarrayFloat32)
-			float32	outarrayFloat32[10] = {0.0};	//Real
+           The attributes comment define the port attributes and is optional.
+           The name comment defines the name of the port and is optional. Default is the name of the field.
+        */
 
-			//#port
-			//#attributes(Output|Retain)
-			//#name(outarrayFloat64)
-			float64	outarrayFloat64[10] = {0.0};	//LREAL
 
-		private: // fields
-			CppDataTypeTest::CppDataTypeTestComponent& cppDataTypeTestComponent;
 
-		};
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outBoolean)
+	boolean	outBoolean		=	false;	//BOOL
 
-		///////////////////////////////////////////////////////////////////////////////
-		// inline methods of class ProgramBase
-		inline CppDataTypeTestProgram::CppDataTypeTestProgram(CppDataTypeTest::CppDataTypeTestComponent& cppDataTypeTestComponentArg, const String& name)
-		: ProgramBase(name)
-		, cppDataTypeTestComponent(cppDataTypeTestComponentArg)
-		{
-		}
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outInt8)
+	int8	outInt8		=	0; 		//SINT
 
-		} // end of namespace CppDataTypeTest
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outUint8)
+	uint8	outUint8	=	0;		//USINT
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outInt16)
+	int16	outInt16	=	0;		//INT
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outUint16)
+	uint16	outUint16	=	0;		//UINT
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outInt32)
+	int32	outInt32	=	0;		//DINT
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outUint32)
+	uint32	outUint32	=	0;		//UDINT
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outInt64)
+	int64 	outInt64	=	0;		//LINT
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outUint64)
+	uint64	outUint64	=	0;		//ULINT
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outByte)
+	uint8	outByte		=	0;		//Byte
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outWord)
+	uint16	outWord		=	0;		//Word
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outDword)
+	uint32	outDword	=	0;		//DWORD
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outLword)
+	uint64	outLword	=	0;		//LWORD
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outFloat32)
+	float32	outFloat32	=	0.0;	//Real
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outFloat64)
+	float64	outFloat64	=	0.0;	//LREAL
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outString)
+ 	StaticString<80> outString = "";  // String
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outString420)
+ 	StaticString<420> outString420 = "";  // Custom-length string
+
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outStruct)
+	s_alltypes outStruct;
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayBoolean)
+    boolean	outarrayBoolean	[10] = {false};	//BOOL
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayInt8)
+ 	int8	outarrayInt8[10] = {0};		//SINT
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayUint8)
+ 	uint8	outarrayUint8[10] = {0};	//USINT
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayInt16)
+ 	int16	outarrayInt16[10] = {0};	//INT
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayUint16)
+ 	uint16	outarrayUint16[10] = {0};	//UINT
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayInt32)
+ 	int32	outarrayInt32[10] = {0};	//DINT
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayUint32)
+ 	uint32	outarrayUint32[10] = {0};	//UDINT
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayInt64)
+ 	int64 	outarrayInt64[10] = {0};	//LINT
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayUint64)
+ 	uint64	outarrayUint64[10] = {0};	//ULINT
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayByte)
+ 	uint8	outarrayByte[10] = {0};		//Byte
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayWord)
+ 	uint16	outarrayWord[10] = {0};		//Word
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayDword)
+ 	uint32	outarrayDword[10] = {0};	//DWORD
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayLword)
+ 	uint64	outarrayLword[10] = {0};	//LWORD
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayFloat32)
+ 	float32	outarrayFloat32[10] = {0.0};//Real
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayFloat64)
+ 	float64	outarrayFloat64[10] = {0.0};//LREAL
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayString)
+ 	StaticString<80> outarrayString[10] = {""};  // String
+
+ 	// Array of custom-length strings are currently not supported by PLCnext  Engineer (version 2020.6).
+
+private: // fields
+    CppDataTypeTest::CppDataTypeTestComponent& cppDataTypeTestComponent;
+
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// inline methods of class ProgramBase
+inline CppDataTypeTestProgram::CppDataTypeTestProgram(CppDataTypeTest::CppDataTypeTestComponent& cppDataTypeTestComponentArg, const String& name)
+: ProgramBase(name)
+, cppDataTypeTestComponent(cppDataTypeTestComponentArg)
+{
+}
+
+} // end of namespace CppDataTypeTest
 
 ```
 
@@ -378,102 +406,107 @@ All supported elementary data types are documented in the [PLCnext Info Center](
 
 ### CppDataTypeTestProgram.cpp
 ```cpp
-		/******************************************************************************
-		 * 
-		 * Copyright (c) Phoenix Contact GmbH & Co. KG. All rights reserved.  
-		 * Licensed under the MIT. See LICENSE file in the project root for full license information.  
-		 *
-		 *  CppDataTypeTestProgram.cpp
-		 *
-		 *  Created on: 21.02.2019
-		 *  	Author: Eduard Münz, Oliver Warneke
-		 *
-		 ******************************************************************************/
+/******************************************************************************
+ * 
+ * Copyright (c) Phoenix Contact GmbH & Co. KG. All rights reserved.  
+ * Licensed under the MIT. See LICENSE file in the project root for full license information.  
+ *
+ *  CppDataTypeTestProgram.cpp
+ *
+ *  Created on: 21.02.2019
+ *  	Author: Eduard Münz, Oliver Warneke, Martin Boers
+ *
+ ******************************************************************************/
 
-		/******************************************************************************/
-		/*  INCLUDES                                                                  */
-		/******************************************************************************/
+/******************************************************************************/
+/*  INCLUDES                                                                  */
+/******************************************************************************/
 
-		#include "CppDataTypeTestProgram.hpp"
-		#include "Arp/System/Commons/Logging.h"
-		#include "Arp/System/Core/ByteConverter.hpp"
+#include "CppDataTypeTestProgram.hpp"
+#include "Arp/System/Commons/Logging.h"
+#include "Arp/System/Core/ByteConverter.hpp"
 
-		namespace CppDataTypeTest
-		{
-		 
-		void CppDataTypeTestProgram::Execute()
-		{
-			//implement program 
-
-
-			if(outBoolean == true)
-					outBoolean = false;
-				else
-					outBoolean = true;
-
-			outInt8++;	//SINT
-			outUint8++;	//USINT
-			outStruct.outInt8++;	//StructElement
-			outStruct.outUint8++;	//StructElement
-
-			outInt16++;	//INT
-			outUint16++;	//UINT
-			outStruct.outInt16++;	//StructElement
-			outStruct.outUint16++;	//StructElement
-
-			outInt32++;	//DINT
-			outUint32++;	//UDINT
-			outStruct.outInt32++;	//StructElement
-			outStruct.outUint32++;	//StructElement
-
-			outInt64++;	//LINT
-			outUint64++;	//ULINT
-			outStruct.outInt64++;	//StructElement
-			outStruct.outUint64++;	//StructElement
-
-			outFloat32++;	//REAL
-			outFloat64++;	//LREAL
-			outStruct.outFloat32++;	//StructElement
-			outStruct.outFloat64++;	//StructElement
-
-			outByte++;	//Byte
-			outWord++;	//Word
-			outDword++;	//DWORD
-			outLword++;	//Lword
-			outStruct.outByte++; //StructElement
-			outStruct.outWord++; //StructElement
-			outStruct.outDword++; //StructElement
-			outStruct.outLword++; //StructElement
+namespace CppDataTypeTest
+{
+ 
+void CppDataTypeTestProgram::Execute()
+{
+    //implement program 
 
 
-			for(int i=0; i < 10;i++)
-			{
-				if(outarrayBoolean[i] == true)
-					outarrayBoolean[i] = false;
-				else
-					outarrayBoolean[i] = true;
+	if(outBoolean == true)
+			outBoolean = false;
+		else
+			outBoolean = true;
 
-				outarrayInt8[i]++;	//SINT
-				outarrayUint8[i]++;	//USINT
+	outInt8++; 	//SINT
+	outUint8++;	//USINT
+	outStruct.outInt8++; //StructElement
+	outStruct.outUint8++; //StructElement
 
-				outarrayInt16[i]++;	//INT
-				outarrayUint16[i]++;	//UINT
+	outInt16++;	//INT
+	outUint16++;//UINT
+	outStruct.outInt16++; //StructElement
+	outStruct.outUint16++; //StructElement
 
-				outarrayInt32[i]++;	//DINT
-				outarrayUint32[i]++;	//UDINT
+	outInt32++;	//DINT
+	outUint32++;//UDINT
+	outStruct.outInt32++; //StructElement
+	outStruct.outUint32++; //StructElement
 
-				outarrayInt64[i]++;	//LINT
-				outarrayUint64[i]++;	//ULINT
+	outInt64++;	//LINT
+	outUint64++;//ULINT
+	outStruct.outInt64++; //StructElement
+	outStruct.outUint64++; //StructElement
 
-				outarrayFloat32[i]++;	//REAL
-				outarrayFloat64[i]++;	//LREAL
+	outFloat32++;//REAL
+	outFloat64++;//LREAL
+	outStruct.outFloat32++; //StructElement
+	outStruct.outFloat64++; //StructElement
 
-				outarrayByte[i]++;	//Byte
-				outarrayWord[i]++;	//Word
-				outarrayDword[i]++;	//DWORD
-				outarrayLword[i]++;	//Lword
-			}
-		}
+	outByte++;	//Byte
+	outWord++;	//Word
+	outDword++;	//DWORD
+	outLword++;	//Lword
+	outStruct.outByte++; //StructElement
+	outStruct.outWord++; //StructElement
+	outStruct.outDword++; //StructElement
+	outStruct.outLword++; //StructElement
 
-		} // end of namespace CppDataTypeTest
+	outString = "This is a standard IEC 61131 string (max. 80 char).";
+	outString420 = "This is a custom length string - in this case, with a maximum of 420 chars, but can be up to 32766 chars.";
+	outStruct.outString = "This is a standard IEC 61131 string (max. 80 char).";  //StructElement
+
+	for(int i=0; i < 10;i++)
+	{
+		if(outarrayBoolean[i] == true)
+			outarrayBoolean[i] = false;
+		else
+			outarrayBoolean[i] = true;
+
+		outarrayInt8[i]++; 	//SINT
+		outarrayUint8[i]++;	//USINT
+
+		outarrayInt16[i]++;	//INT
+		outarrayUint16[i]++;//UINT
+
+		outarrayInt32[i]++;	//DINT
+		outarrayUint32[i]++;//UDINT
+
+		outarrayInt64[i]++;	//LINT
+		outarrayUint64[i]++;//ULINT
+
+		outarrayFloat32[i]++;//REAL
+		outarrayFloat64[i]++;//LREAL
+
+		outarrayByte[i]++;	//Byte
+		outarrayWord[i]++;	//Word
+		outarrayDword[i]++;	//DWORD
+		outarrayLword[i]++;	//Lword
+
+		outarrayString[i] = "This is a standard IEC 61131 string (max. 80 chars).";
+	}
+}
+
+} // end of namespace CppDataTypeTest
 ```

--- a/Examples/CppDataTypeTest/src/CppDataTypeTestProgram.cpp
+++ b/Examples/CppDataTypeTest/src/CppDataTypeTestProgram.cpp
@@ -6,7 +6,7 @@
  *  CppDataTypeTestProgram.cpp
  *
  *  Created on: 21.02.2019
- *  	Author: Eduard Münz, Oliver Warneke
+ *  	Author: Eduard Münz, Oliver Warneke, Martin Boers
  *
  ******************************************************************************/
 
@@ -65,6 +65,9 @@ void CppDataTypeTestProgram::Execute()
 	outStruct.outDword++; //StructElement
 	outStruct.outLword++; //StructElement
 
+	outString = "This is a standard IEC 61131 string (max. 80 char).";
+	outString420 = "This is a custom length string - in this case, with a maximum of 420 chars, but can be up to 32766 chars.";
+	outStruct.outString = "This is a standard IEC 61131 string (max. 80 char).";  //StructElement
 
 	for(int i=0; i < 10;i++)
 	{
@@ -92,6 +95,8 @@ void CppDataTypeTestProgram::Execute()
 		outarrayWord[i]++;	//Word
 		outarrayDword[i]++;	//DWORD
 		outarrayLword[i]++;	//Lword
+
+		outarrayString[i] = "This is a standard IEC 61131 string (max. 80 chars).";
 	}
 }
 

--- a/Examples/CppDataTypeTest/src/CppDataTypeTestProgram.hpp
+++ b/Examples/CppDataTypeTest/src/CppDataTypeTestProgram.hpp
@@ -6,7 +6,7 @@
  *  CppDataTypeTestProgram.hpp
  *
  *  Created on: 21.02.2019
- *  	Author: Eduard Münz, Oliver Warneke
+ *  	Author: Eduard Münz, Oliver Warneke, Martin Boers
  *
  ******************************************************************************/
 
@@ -55,6 +55,9 @@ public: // typedefs
 
 		float32	outFloat32	=	0.0;	//Real
 		float64	outFloat64	=	0.0;	//LREAL
+
+		StaticString<80> outString = "";  // String
+		// Structs containing custom-length strings  are currently not supported by PLCnext Engineer (version 2020.6).
 
 	};
 
@@ -160,6 +163,16 @@ public: /* Ports
 	//#name(outFloat64)
 	float64	outFloat64	=	0.0;	//LREAL
 
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outString)
+ 	StaticString<80> outString = "";  // String
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outString420)
+ 	StaticString<420> outString420 = "";  // Custom-length string
+
 
 	//#port
 	//#attributes(Output|Retain)
@@ -240,6 +253,13 @@ public: /* Ports
 	//#attributes(Output|Retain)
 	//#name(outarrayFloat64)
  	float64	outarrayFloat64[10] = {0.0};//LREAL
+
+	//#port
+	//#attributes(Output|Retain)
+	//#name(outarrayString)
+ 	StaticString<80> outarrayString[10] = {""};  // String
+
+ 	// Array of custom-length strings are currently not supported by PLCnext  Engineer (version 2020.6).
 
 private: // fields
     CppDataTypeTest::CppDataTypeTestComponent& cppDataTypeTestComponent;


### PR DESCRIPTION
Added the following ports to the Data Types example:

- STRING
- STRING[420]
- array of STRING
- element of type STRING to the STRUCT port

Also unsuccessfully tried to add the following:

- array of STRING[420]
- element of type STRING[420] to the STRUCT port

In those last two cases, PLCnext Engineer does not allow the equivalent IEC & C++ port types to be matched.