### PR TITLE
ThreadExample fix#16 undefined behavior when generating threads / -Worder issue

### DIFF
--- a/Examples/ThreadExample/src/ThreadExampleComponent.cpp
+++ b/Examples/ThreadExample/src/ThreadExampleComponent.cpp
@@ -21,20 +21,18 @@
 
 namespace ThreadExample
 {
-
-///////////////////////////////////////////////////////////////////////////////
-// inline methods of class ThreadExampleComponent
+///
+///ThreadExampleComponent Constructor
+///
 ThreadExampleComponent::ThreadExampleComponent(IApplication& application, const String& name)
 : ComponentBase(application, ::ThreadExample::ThreadExampleLibrary::GetInstance(), name, ComponentCategory::Custom)
 , programProvider(*this)
 , ProgramComponentBase(::ThreadExample::ThreadExampleLibrary::GetInstance().GetNamespace(), programProvider)
-
 // Worker Thread Example
 , workerThreadInstance(make_delegate(this, &ThreadExampleComponent::workerThreadBody) , 10000, "WorkerThreadName")
-
 //Commons/Thread Example
-, delegateThreadInstance(delegateThreadSettings,this,&ThreadExampleComponent::delegateThreadBody,(void*)&myparameter)
-, staticThreadInstance(staticThreadSettings,&ThreadExampleComponent::staticThreadBody,(void*)&xStopThread)
+, delegateThreadInstance(ThreadSettings("DelegateThreadName", 20, 0, 0),this,&ThreadExampleComponent::delegateThreadBody,(void*)&myparameter)
+, staticThreadInstance(ThreadSettings("StaticThreadName", 20, 0, 0),&ThreadExampleComponent::staticThreadBody,(void*)&xStopThread)
 {
 }
 

--- a/Examples/ThreadExample/src/ThreadExampleComponent.hpp
+++ b/Examples/ThreadExample/src/ThreadExampleComponent.hpp
@@ -85,7 +85,7 @@ private: // fields
 
     void workerThreadBody(void);
 
-     //Commons/Thread Example
+    //Commons/Thread Example
     Thread delegateThreadInstance;
     Thread staticThreadInstance;
 

--- a/Examples/ThreadExample/src/ThreadExampleComponent.hpp
+++ b/Examples/ThreadExample/src/ThreadExampleComponent.hpp
@@ -85,12 +85,11 @@ private: // fields
 
     void workerThreadBody(void);
 
-    //Commons/Thread Example
+     //Commons/Thread Example
     Thread delegateThreadInstance;
     Thread staticThreadInstance;
 
-    ThreadSettings delegateThreadSettings {"DelegateThreadName", 0, 0, 0};
-    ThreadSettings staticThreadSettings {"StaticThreadName", 0, 0, 0};
+
 
     void delegateThreadBody(void * pParameter);
 


### PR DESCRIPTION
The ThreadSettings and Thread variables are ordered wrongly resulting in a undefined behavior at construction time.
Fix has been implemented.

This can be noticed at compile time by activating "-Worder" compiler warning -> this will be updated in later SDK versions.
For example adding this to CMakeLists.txt
target_compile_options(ThreadExample PRIVATE "-Wall")